### PR TITLE
Fix gradle build failure when missing npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Please have a look at the [developer guidelines](/docs/DEVELOPMENT.md).
 To run the QuaK editor, run 
 `gradlew bootRun`
 inside the `backend` directory
+
+### Automatic installation of nodejs
+Through the use of the [gradle-node-plugin], the project can automatically install `npm`.
+If you want to use this feature, run any gradle-command with the flag `-PdownloadNode` (i.e. `gradlew :bootRun -PdownloadNode`).
+
+If you wish to remove the custom nodejs install, run `gradlew :removeCustomNode`.
+
+[gradle-node-plugin]: https://github.com/node-gradle/gradle-node-plugin

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ To run the QuaK editor, run
 `gradlew bootRun`
 inside the `backend` directory
 
+### Dependencies
+The project requires the following dependencies to be installed on the system:
+* Java >= Version 21
+
 ### Automatic installation of nodejs
 Through the use of the [gradle-node-plugin], the project can automatically install `npm`.
 If you want to use this feature, run any gradle-command with the flag `-PdownloadNode` (i.e. `gradlew :bootRun -PdownloadNode`).

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 	id "com.github.node-gradle.node" version "7.1.0"
 }
+apply from: 'node.gradle'
 
 group = 'edu.kit'
 version = '0.0.1-SNAPSHOT'
@@ -16,13 +17,6 @@ java {
 
 repositories {
 	mavenCentral()
-}
-
-// Add the commandline-flag "-PdownloadNode" to a task to download node
-// via the gradle-node-plugin.
-// Use the task removeCustomNode to delete the downloaded version
-if (project.hasProperty("downloadNode")) {
-	node.download = true
 }
 
 dependencies {
@@ -41,23 +35,6 @@ tasks.register('cleanFrontendFiles', Delete) {
 		!file.name.startsWith(".git")
 	}
 	delete toDelete
-}
-
-tasks.named("npm_install") {
-	workingDir = layout.projectDirectory.file("../frontend")
-}
-
-tasks.named("npm_run_build") {
-	dependsOn {
-		tasks.named("npm_install")
-	}
-	workingDir = layout.projectDirectory.file("../frontend")
-}
-
-tasks.register("removeCustomNode", Delete) {
-	delete node.workDir
-	delete node.npmWorkDir
-	delete node.yarnWorkDir
 }
 
 tasks.register('getFrontend', Copy) {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,6 +18,13 @@ repositories {
 	mavenCentral()
 }
 
+// Add the commandline-flag "-PdownloadNode" to a task to download node
+// via the gradle-node-plugin.
+// Use the task removeCustomNode to delete the downloaded version
+if (project.hasProperty("downloadNode")) {
+	node.download = true
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
@@ -47,6 +54,12 @@ tasks.named("npm_run_build") {
 	workingDir = layout.projectDirectory.file("../frontend")
 }
 
+tasks.register("removeCustomNode", Delete) {
+	delete node.workDir
+	delete node.npmWorkDir
+	delete node.yarnWorkDir
+}
+
 tasks.register('getFrontend', Copy) {
 	dependsOn npm_run_build
 	dependsOn cleanFrontendFiles
@@ -64,7 +77,6 @@ tasks.named("bootRun") {
 	group = 'QuaK'
 	mainClass = 'edu.kit.quak.QuaKApplication'
 }
-
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "com.github.node-gradle.node" version "7.1.0"
 }
 
 group = 'edu.kit'
@@ -35,13 +36,19 @@ tasks.register('cleanFrontendFiles', Delete) {
 	delete toDelete
 }
 
-tasks.register('npmRunBuild', Exec) {
-	workingDir = layout.projectDirectory.dir("../frontend").toString()
-	commandLine 'npm', 'run', 'build'
+tasks.named("npm_install") {
+	workingDir = layout.projectDirectory.file("../frontend")
+}
+
+tasks.named("npm_run_build") {
+	dependsOn {
+		tasks.named("npm_install")
+	}
+	workingDir = layout.projectDirectory.file("../frontend")
 }
 
 tasks.register('getFrontend', Copy) {
-	dependsOn npmRunBuild
+	dependsOn npm_run_build
 	dependsOn cleanFrontendFiles
 	dependsOn processResources
 	group = 'QuaK'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,17 +50,18 @@ tasks.named("npm_run_build") {
 tasks.register('getFrontend', Copy) {
 	dependsOn npm_run_build
 	dependsOn cleanFrontendFiles
-	dependsOn processResources
 	group = 'QuaK'
 	description = 'Copy frontend into static-folder inside the backend'
 	from(layout.projectDirectory.dir("../frontend/dist"))
 	into(layout.projectDirectory.dir('src/main/resources/static'))
 }
 
+tasks.named("processResources") {
+	dependsOn getFrontend
+}
 
 tasks.named("bootRun") {
 	group = 'QuaK'
-	dependsOn getFrontend
 	mainClass = 'edu.kit.quak.QuaKApplication'
 }
 

--- a/backend/node.gradle
+++ b/backend/node.gradle
@@ -1,0 +1,23 @@
+// Add the commandline-flag "-PdownloadNode" to a task to download node
+// via the gradle-node-plugin.
+// Use the task removeCustomNode to delete the downloaded version
+if (project.hasProperty("downloadNode")) {
+    node.download = true
+}
+
+tasks.register("removeCustomNode", Delete) {
+    delete node.workDir
+    delete node.npmWorkDir
+    delete node.yarnWorkDir
+}
+
+tasks.named("npm_install") {
+    workingDir = layout.projectDirectory.file("../frontend")
+}
+
+tasks.named("npm_run_build") {
+    dependsOn {
+        tasks.named("npm_install")
+    }
+    workingDir = layout.projectDirectory.file("../frontend")
+}


### PR DESCRIPTION
Closes #4.

Gradle now uses the [gradle-node-plugin](https://github.com/node-gradle/gradle-node-plugin) to execute `npm`-commands.
As it is decribed in the `README.md`, users can now set a specific flag to download node via the plugin, if they don't have nodejs installed.