### PR TITLE
Change header-name 'parent_id' to 'parent-id'

### DIFF
--- a/backend/src/main/java/edu/kit/quak/files/FileController.java
+++ b/backend/src/main/java/edu/kit/quak/files/FileController.java
@@ -53,7 +53,7 @@ public class FileController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/")
-    public FileElement<?> newFile(@RequestBody Map<String, Object> obj, @RequestHeader(name = "parent_id") String parent) {
+    public FileElement<?> newFile(@RequestBody Map<String, Object> obj, @RequestHeader(name = "parent-id") String parent) {
         final RepoMonad<?> dest = savers.getSaverForElementId(parent)
                                         .flatMap(FileElementSaver::getRepoMonad)
                                         .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "No matching parent found"));

--- a/backend/src/main/java/edu/kit/quak/files/repository/RepoMonad.java
+++ b/backend/src/main/java/edu/kit/quak/files/repository/RepoMonad.java
@@ -29,7 +29,7 @@ public class RepoMonad<T extends FileElementContainer<?>> {
      */
     public FileElementContainer<?> addAndSave(String id, FileElement<?> element) throws IllegalArgumentException {
         T container = repo.findById(id).orElseThrow(
-                () -> new IllegalArgumentException("Provided parent_id does not map to an existing element.")
+                () -> new IllegalArgumentException("Provided parent-id does not map to an existing element.")
         );
         element.setParent(container);
         repo.save(container);

--- a/backend/src/main/resources/api.yaml
+++ b/backend/src/main/resources/api.yaml
@@ -165,7 +165,7 @@ paths:
         This will only create the metadata of the file.
         The content of a file is initialized as empty, similar to the touch command in unix.
       parameters:
-        - name: parent_id
+        - name: parent-id
           in: header
           required: true
           description: ID of the parent-container

--- a/backend/src/test/java/edu/kit/quak/files/FileControllerTest.java
+++ b/backend/src/test/java/edu/kit/quak/files/FileControllerTest.java
@@ -67,7 +67,7 @@ class FileControllerTest extends QuaKApplicationTests {
                 post("/file/")
                         .content(sent.toString())
                         .contentType(JSON_CONTENT_TYPE)
-                        .header("parent_id", parent.getId())
+                        .header("parent-id", parent.getId())
                 ).andExpectAll(
                         status().isCreated(),
                         content().contentType(JSON_CONTENT_TYPE),
@@ -93,7 +93,7 @@ class FileControllerTest extends QuaKApplicationTests {
                 post("/file/")
                         .content(sent.toString())
                         .contentType(JSON_CONTENT_TYPE)
-                        .header("parent_id", parent.getId())
+                        .header("parent-id", parent.getId())
         ).andExpectAll(
                 status().isCreated(),
                 content().contentType(JSON_CONTENT_TYPE),
@@ -311,7 +311,7 @@ class FileControllerTest extends QuaKApplicationTests {
         File parent = files.save(new File("parent", null));
         mockMvc.perform(
                 get("/file/")
-                        .header("parent_id", parent.getId())
+                        .header("parent-id", parent.getId())
         ).andExpect(
                 status().is4xxClientError()
         );
@@ -363,7 +363,7 @@ class FileControllerTest extends QuaKApplicationTests {
 
         mockMvc.perform(
                 post("/file/")
-                    .header("parent_id", parent.getId())
+                    .header("parent-id", parent.getId())
                     .contentType(JSON_CONTENT_TYPE)
                     .content(toSend.toString())
         ).andExpectAll(
@@ -387,7 +387,7 @@ class FileControllerTest extends QuaKApplicationTests {
 
         MvcResult result = mockMvc.perform(
                 post("/file/")
-                        .header("parent_id", parent.getId())
+                        .header("parent-id", parent.getId())
                         .contentType(JSON_CONTENT_TYPE)
                         .content(toSend.toString())
         ).andExpectAll(

--- a/frontend/src/views/project-manager-view/CreateDialog.tsx
+++ b/frontend/src/views/project-manager-view/CreateDialog.tsx
@@ -79,7 +79,7 @@ function CreateFile({parent}: {parent: string}) {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                'parent_id': parent
+                'parent-id': parent
             },
             body: JSON.stringify(body),
         }).then(reloadParent)
@@ -133,7 +133,7 @@ function CreateDirectory({parent}: {parent: string}) {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                'parent_id': parent
+                'parent-id': parent
             },
             body: JSON.stringify(body),
         }).then(reloadParent)


### PR DESCRIPTION
When deploying the Application using nginx, the header 'parent_id' would not get forwarded by nginx.
Apparently this is due to the header-name containing the char '_'.
This will result in files and directories not being created because the request is rejected.

Although one could supposedly add a rule to the nginx config to allow for forwarding of this type of header, I figure that it is easier to just change this header-name to be more inline with other headers.