### PR TITLE
Fix large icon size in ProjectManagerView

### DIFF
--- a/frontend/src/views/project-manager-view/ProjectManagerView.css
+++ b/frontend/src/views/project-manager-view/ProjectManagerView.css
@@ -5,3 +5,8 @@
 .entry:hover {
     text-decoration: underline;
 }
+
+.entry .lucide, .create-project .lucide {
+    height: revert-layer;
+    width: revert-layer;
+}

--- a/frontend/src/views/project-manager-view/ProjectManagerView.tsx
+++ b/frontend/src/views/project-manager-view/ProjectManagerView.tsx
@@ -96,7 +96,7 @@ function CreateProject({reload}: {reload: () => void}) {
 
     return (
         <Dialog>
-            <DialogTrigger asChild>
+            <DialogTrigger asChild className="create-project">
                 <Button className="w-full" variant="ghost"><Plus/></Button>
             </DialogTrigger>
             <DialogContent>


### PR DESCRIPTION
This fix simply reverts the changes made further up in the tree. It does not infer with the icon size set for the
library-view/circuit-view.