### PR TITLE
Feature/30 feature add light mode support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
 
 <head>
   <meta charset="UTF-8" />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Home, User, Settings, LogOut } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import ThemeSwitch from "@/components/ThemeSwitch";
 
 export const Navbar: React.FC = () => {
   const location = useLocation();
@@ -57,6 +58,7 @@ export const Navbar: React.FC = () => {
 
       {user && (
         <div className="flex items-center gap-4">
+         <ThemeSwitch />
           <div className="flex items-center gap-3">
             {user.picture && (
               <img

--- a/frontend/src/components/ThemeSwitch.tsx
+++ b/frontend/src/components/ThemeSwitch.tsx
@@ -21,14 +21,14 @@ export default function ThemeSwitch({ onToggle }: ThemeSwitchProps) {
       className="
         relative flex items-center
         w-14 h-7 rounded-full
-        bg-gray-300
+        bg-gray-100
         p-1
       "
     >
       {isDark ? (
-        <Moon className="absolute right-7 w-5 h-5 text-gray-700 pointer-events-none" />
+        <Sun className="absolute right-7 w-5 h-5 text-orange-300 pointer-events-none" />
       ) : (
-        <Sun className="absolute left-7 w-5 h-5 text-yellow-500 pointer-events-none" />
+        <Moon className="absolute left-7 w-5 h-5 text-gray-700 pointer-events-none" />
       )}
 
       {/* Thumb */}

--- a/frontend/src/components/ThemeSwitch.tsx
+++ b/frontend/src/components/ThemeSwitch.tsx
@@ -1,0 +1,45 @@
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/theme";
+
+type ThemeSwitchProps = {
+  onToggle?: (isDark: boolean) => void;
+};
+
+export default function ThemeSwitch({ onToggle }: ThemeSwitchProps) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  const handleClick = () => {
+    toggleTheme();
+    onToggle?.(!isDark); // after toggle, it becomes the opposite
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="Toggle theme"
+      className="
+        relative flex items-center
+        w-14 h-7 rounded-full
+        bg-gray-300
+        p-1
+      "
+    >
+      {isDark ? (
+        <Moon className="absolute right-5 w-2 h-2 text-gray-700 pointer-events-none" />
+      ) : (
+        <Sun className="absolute left-5 w-2 h-2 text-yellow-500 pointer-events-none" />
+      )}
+
+      {/* Thumb */}
+      <span
+        className={`
+          absolute top-1 left-1
+          w-5 h-5 rounded-full bg-white
+          transition-transform duration-300
+          ${isDark ? "translate-x-7" : "translate-x-0"}
+        `}
+      />
+    </button>
+  );
+}

--- a/frontend/src/components/ThemeSwitch.tsx
+++ b/frontend/src/components/ThemeSwitch.tsx
@@ -11,7 +11,7 @@ export default function ThemeSwitch({ onToggle }: ThemeSwitchProps) {
 
   const handleClick = () => {
     toggleTheme();
-    onToggle?.(!isDark); // after toggle, it becomes the opposite
+    onToggle?.(!isDark);
   };
 
   return (

--- a/frontend/src/components/ThemeSwitch.tsx
+++ b/frontend/src/components/ThemeSwitch.tsx
@@ -26,9 +26,9 @@ export default function ThemeSwitch({ onToggle }: ThemeSwitchProps) {
       "
     >
       {isDark ? (
-        <Moon className="absolute right-5 w-2 h-2 text-gray-700 pointer-events-none" />
+        <Moon className="absolute right-7 w-5 h-5 text-gray-700 pointer-events-none" />
       ) : (
-        <Sun className="absolute left-5 w-2 h-2 text-yellow-500 pointer-events-none" />
+        <Sun className="absolute left-7 w-5 h-5 text-yellow-500 pointer-events-none" />
       )}
 
       {/* Thumb */}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-blue-1000 text-muted-foreground inline-flex h-12 w-fit items-center justify-center rounded-lg p-1",
+        "inline-flex h-12 w-fit items-center justify-center rounded-lg p-1 text-muted-foreground",
         className
       )}
       {...props}
@@ -40,7 +40,31 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-blue-500 data-[state=active]:text-white focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-gray-300 hover:text-white inline-flex h-[calc(100%-8px)] flex-1 items-center justify-center gap-2 rounded-md border border-transparent px-4 py-2 text-base font-medium whitespace-nowrap transition-all focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-md [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
+        `
+        inline-flex h-[calc(100%-8px)] flex-1 items-center justify-center gap-2
+        rounded-md border border-transparent px-4 py-2 text-base font-medium
+        whitespace-nowrap transition-all
+
+        text-muted-foreground
+        hover:text-foreground
+
+        data-[state=active]:bg-accent
+        data-[state=active]:text-accent-foreground
+        data-[state=active]:shadow-md
+
+        focus-visible:border-ring
+        focus-visible:ring-ring/50
+        focus-visible:outline-ring
+        focus-visible:ring-[3px]
+        focus-visible:outline-1
+
+        disabled:pointer-events-none
+        disabled:opacity-50
+
+        [&_svg]:pointer-events-none
+        [&_svg]:shrink-0
+        [&_svg:not([class*='size-'])]:size-5
+        `,
         className
       )}
       {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,7 @@
   --radius-xl: calc(var(--radius) + 4px);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-probability: var(--probability);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
@@ -41,80 +42,82 @@
 }
 
 :root {
-  --radius: 0.65rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(0 0% 0%);
+
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(0 0% 0%);
+
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(0 0% 0%);
+
+  --primary: hsl(0 0% 0%);
+  --primary-foreground: hsl(0 0% 100%);
+
+  --secondary: hsl(0 0% 100%);
+  --secondary-foreground: hsl(0 0% 0%);
+
+  --muted: hsl(0 0% 100%);
+  --muted-foreground: hsl(0 0% 0%);
+
+  --accent: hsl(0 0% 100%);
+  --accent-foreground: hsl(0 0% 0%);
+
+  --destructive: hsl(0 84% 60%);
+
+  --border: hsl(0 0% 90%);
+  --input: hsl(0 0% 90%);
+  --ring: hsl(0 0% 70%);
+
+  --sidebar: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(0 0% 12%);
+  --sidebar-primary: hsl(0 0% 12%);
+  --sidebar-primary-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(0 0% 96%);
+  --sidebar-accent-foreground: hsl(0 0% 12%);
+  --sidebar-border: hsl(0 0% 90%);
+  --sidebar-ring: hsl(0 0% 70%);
+  --probability: hsl(220 80% 56%); /* temporary for the bars in the results*/
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: hsl(0 0% 0%);
+  --foreground: hsl(0 0% 90%);
+  --card: hsl(0 0% 5%);
+  --card-foreground: hsl(0 0% 98%);
+  --popover: hsl(0 0% 16%);
+  --popover-foreground: hsl(0 0% 98%);
+  --primary: hsl(0 0% 90%);
+  --primary-foreground: hsl(0 0% 5%);
+  --secondary: hsl(0 0% 22%);
+  --secondary-foreground: hsl(0 0% 98%);
+  --muted: hsl(0 0% 22%);
+  --muted-foreground: hsl(0 0% 65%);
+  --accent: hsl(0 0% 0%);
+  --accent-foreground: hsl(0 0% 98%);
+  --destructive: hsl(0 72% 50%);
+  --border: hsl(0 0% 100% / 10%);
+  --input: hsl(0 0% 100% / 15%);
+  --ring: hsl(0 0% 55%);
+  --sidebar: hsl(0 0% 16%);
+  --sidebar-foreground: hsl(0 0% 98%);
+  --sidebar-primary: hsl(220 80% 60%);
+  --sidebar-primary-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(0 0% 22%);
+  --sidebar-accent-foreground: hsl(0 0% 98%);
+  --sidebar-border: hsl(0 0% 100% / 10%);
+  --sidebar-ring: hsl(0 0% 55%);
+  --probability: hsl(0 0% 100%); /*temporary for the bars in the results*/
 }
 
 
-.lucide {
+
+/*.lucide {
   width: 40px;
   height: 28px;
-}
+}*/
 
 @layer base {
   * {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,7 +45,7 @@
   --radius: 0.625rem;
 
   --background: hsl(0 0% 100%);
-  --foreground: hsl(0 0% 0%);
+  --foreground: hsl(0 0% 40%);
 
   --card: hsl(0 0% 100%);
   --card-foreground: hsl(0 0% 0%);
@@ -62,7 +62,7 @@
   --muted: hsl(0 0% 100%);
   --muted-foreground: hsl(0 0% 0%);
 
-  --accent: hsl(0 0% 100%);
+  --accent: hsl(0 0% 95%);
   --accent-foreground: hsl(0 0% 0%);
 
   --destructive: hsl(0 84% 60%);
@@ -95,7 +95,7 @@
   --secondary-foreground: hsl(0 0% 98%);
   --muted: hsl(0 0% 22%);
   --muted-foreground: hsl(0 0% 65%);
-  --accent: hsl(0 0% 0%);
+  --accent: hsl(0 0% 10%);
   --accent-foreground: hsl(0 0% 98%);
   --destructive: hsl(0 72% 50%);
   --border: hsl(0 0% 100% / 10%);
@@ -109,7 +109,6 @@
   --sidebar-accent-foreground: hsl(0 0% 98%);
   --sidebar-border: hsl(0 0% 100% / 10%);
   --sidebar-ring: hsl(0 0% 55%);
-  --probability: hsl(0 0% 100%); /*temporary for the bars in the results*/
 }
 
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,12 +3,15 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router.tsx";
+import { ThemeProvider } from "@/theme";
 
 // Enable dark mode globally
-document.documentElement.classList.add('dark');
+//document.documentElement.classList.add('dark');
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <ThemeProvider>
+        <RouterProvider router={router} />
+    </ThemeProvider>
   </StrictMode>
 )

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,8 +4,11 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
+import { useTheme } from "@/theme";
 
 export const Settings: React.FC = () => {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
   return (
     <div className="p-8 max-w-4xl mx-auto">
       <h1 className="text-4xl font-bold mb-6">Settings</h1>
@@ -43,7 +46,8 @@ export const Settings: React.FC = () => {
               </div>
               <input
                 type="checkbox"
-                defaultChecked
+                checked={isDark}
+                onChange={(e) => setTheme(e.target.checked ? "dark" : "light")}
                 className="h-4 w-4 rounded border-gray-300"
               />
             </div>

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,7 +1,11 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 
 type Theme = "dark" | "light";
-type ThemeCtx = { theme: Theme; toggleTheme: () => void };
+type ThemeCtx = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
 
 const ThemeContext = createContext<ThemeCtx | null>(null);
 const KEY = "theme";
@@ -21,7 +25,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <ThemeContext.Provider
-      value={{ theme, toggleTheme: () => setTheme(t => (t === "dark" ? "light" : "dark")) }}
+      value={{ theme, setTheme, toggleTheme: () => setTheme(t => (t === "dark" ? "light" : "dark")) }}
     >
       {children}
     </ThemeContext.Provider>

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -9,7 +9,7 @@ const KEY = "theme";
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     const saved = localStorage.getItem(KEY) as Theme | null;
-    return saved ?? "dark"; // since your app is currently dark by default
+    return saved ?? "dark";
   });
 
   useEffect(() => {

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+type ThemeCtx = { theme: Theme; toggleTheme: () => void };
+
+const ThemeContext = createContext<ThemeCtx | null>(null);
+const KEY = "theme";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = localStorage.getItem(KEY) as Theme | null;
+    return saved ?? "dark"; // since your app is currently dark by default
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") root.classList.add("dark");
+    else root.classList.remove("dark");
+    localStorage.setItem(KEY, theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider
+      value={{ theme, toggleTheme: () => setTheme(t => (t === "dark" ? "light" : "dark")) }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/frontend/src/views/results-view/ResultsView.tsx
+++ b/frontend/src/views/results-view/ResultsView.tsx
@@ -9,10 +9,13 @@ import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 import { useMemo } from "react";
 
 const chartConfig = {
-    probability: {
-        label: "Probability",
-        color: "var(--chart-1)",
+  probability: {
+    label: "Probability",
+    theme: {
+      light: "hsl(220 80% 56%)",
+      dark: "hsl(220 80% 65%)",
     },
+  },
 } satisfies ChartConfig;
 
 type ResultsViewProps = {

--- a/frontend/src/views/results-view/ResultsView.tsx
+++ b/frontend/src/views/results-view/ResultsView.tsx
@@ -40,7 +40,7 @@ export function ResultsView({ numberQubits }: ResultsViewProps) {
             <CardContent>
                 <ChartContainer config={chartConfig}>
                     <BarChart accessibilityLayer data={chartData}>
-                        <CartesianGrid vertical={false} />
+                        <CartesianGrid vertical={false} stroke="var(--color-foreground)" strokeOpacity={0.4} />
                         <XAxis
                             dataKey="qubit"
                             tickLine={false}

--- a/frontend/src/views/text-editor-view/Menu.tsx
+++ b/frontend/src/views/text-editor-view/Menu.tsx
@@ -27,7 +27,7 @@ type language = {
  */
 export function Menu({onSave, languages}: {onSave: saver, languages: language[]}) {
     return (
-        <Menubar className="rounded-none">
+        <Menubar className="rounded-none bg-foreground-light">
             <MenubarMenu>
                 <MenubarTrigger>File</MenubarTrigger>
                 <MenubarContent>

--- a/frontend/src/views/text-editor-view/QLPEditor.tsx
+++ b/frontend/src/views/text-editor-view/QLPEditor.tsx
@@ -7,10 +7,12 @@ import { Language } from "@/views/text-editor-view/model/Language.ts";
 import { qrisp } from "@/components/languages/qrisp.ts";
 import { openqasm } from "@/components/languages/openqasm.ts";
 import { api } from "@/utils/api";
+import { useTheme } from "@/theme";
 
 const DEFAULT_VALUE = "No File Selected";
 const DEFAULT_LANG = "plaintext";
-const THEME = "vs-dark";
+
+
 
 const languages = [
     new Language("plaintext", "txt"),
@@ -24,6 +26,8 @@ function QLPEditor({ file }: { file: File | undefined }) {
     const [lang, setLang] = useState(DEFAULT_LANG);
     const [readOnly, setReadOnly] = useState<boolean>(true);
     const contentId: RefObject<string | undefined> = useRef(undefined);
+    const { theme } = useTheme();
+    const monacoTheme = theme === "dark" ? "vs-dark" : "vs-light";
 
     const onMount = (monaco: Monaco) => {
         for (const language of languages) {
@@ -127,7 +131,7 @@ function QLPEditor({ file }: { file: File | undefined }) {
             <div className="h-full">
                 <Editor
                     language={lang}
-                    theme={THEME}
+                    theme={monacoTheme}
                     value={value}
                     onChange={(value) => setValue(value || '')}
                     options={{


### PR DESCRIPTION
Implement switch to change theme from dark to light. Preference is saved on local storage.
Adjust colors of each theme to be consistent.
Note: A refactoring of how each component style could be done for better maintability
Light mode looks like this:
<img width="2820" height="1491" alt="image" src="https://github.com/user-attachments/assets/f9f5fc1c-f154-40b8-838e-5ce1b8cbf3d3" />
Dark mode looks like this:
<img width="2819" height="1475" alt="image" src="https://github.com/user-attachments/assets/176561ca-42b3-40f2-a148-cb393b7fdd29" />
