### PR TITLE
Remove Hibernate dialect properties from development configuration fi…

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -10,7 +10,6 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 # Development user credentials for HTTP Basic Auth
 app.dev.username=admin

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,7 +7,6 @@ spring.datasource.url=${DB_URL:jdbc:mariadb://localhost:3306/quak}
 spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:hello}
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
 
 # OAuth2 / OIDC Configuration
 spring.security.oauth2.client.registration.google.client-id=${OIDC_CLIENT_ID:your-client-id-here}


### PR DESCRIPTION
- Remove explicit Hibernate dialect overrides so the dialect is auto-detected from JDBC metadata
- Allow Hibernate to create missing tables in Docker-only dev workflow

## Impact
- Docker-only dev: Hibernate now detects the MariaDB dialect automatically and should create missing tables on startup, avoiding the 500 on project creation.
- Dev profile (H2): Hibernate auto-detects H2 rather than forcing a specific dialect, which may slightly change type mapping/DDL but should remain compatible.

## 
Closes #152.